### PR TITLE
Update website to new repo name

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
                             <h1>A Validation System for Secure Peer-to-Peer Exchange</h1>
                             <p class="lead">TPL is a self-regulatory system to support formal decentralized economies while preserving users’ freedom to innovate. By implementing TPL, projects can guarantee regulatory compliance in every single exchange between participants.</p>
                             <a class="btn btn--primary type--uppercase btn--gray add-top-margin" target="_blank" href="pdf/TPL%20-%20Transaction%20Permission%20Layer.pdf"> <span class="btn__text"> Read the full proposal ▸ </span> </a>
-                            <a class="btn btn--primary type--uppercase btn--ghost add-top-margin" target="_blank" href="https://github.com/TPL-protocol/contracts/"> <span class="btn__text"> View on Github </span> </a>
+                            <a class="btn btn--primary type--uppercase btn--ghost add-top-margin" target="_blank" href="https://github.com/TPL-protocol/tpl-contracts/"> <span class="btn__text"> View on Github </span> </a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
`contracts` → `tpl-contracts`

(Note that the previous URL is correctly redirected to the new one anyway.)